### PR TITLE
Gentoo patche - optional RPATH setting 

### DIFF
--- a/common.mk
+++ b/common.mk
@@ -566,8 +566,11 @@ ifeq ($(MK_ENABLE_STATIC),no)
 LIBBLIS_L      := $(LIBBLIS_SO)
 LIBBLIS_LINK   := $(LIBBLIS_SO_PATH)
 ifeq ($(IS_WIN),no)
+BLIS_SET_RPATH ?= yes
+ifeq ($(LIBBLIS_SET_RPATH),yes)
 # For Linux and OS X: set rpath property of shared object.
 LDFLAGS        += -Wl,-rpath,$(BASE_LIB_PATH)
+endif
 endif
 endif
 # On windows, use the shared library even if static is created.

--- a/configure
+++ b/configure
@@ -3055,7 +3055,7 @@ main()
 		enable_aocl_zen='yes'
 		enable_aocl_zen_01=1
 	else
-		enable_aocl_zen = 'no';
+		enable_aocl_zen='no';
 		enable_aocl_zen_01=0;
 	fi
 


### PR DESCRIPTION
This makes `RPATH` setting optional as the location of libraries is not fixed and can be moved around.

It should have no effect on normal installation but is useful in many cases

Thanks,
Aisha